### PR TITLE
Enable call recording for IVR

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -11,3 +11,5 @@ Route::match(['GET', 'POST'], '/ivr/welcome', [IvrController::class, 'welcome'])
 Route::match(['GET', 'POST'], '/ivr/age-response', [IvrController::class, 'ageResponse'])->name('age-response');
 Route::match(['GET', 'POST'], '/ivr/main-menu', [IvrController::class, 'mainMenu'])->name('main-menu');
 Route::match(['GET', 'POST'], '/ivr/main-response', [IvrController::class, 'mainResponse'])->name('main-response');
+Route::match(['GET', 'POST'], '/ivr/recording-cb', [IvrController::class, 'recordingCallback'])->name('recording-cb');
+

--- a/tests/IvrControllerTest.php
+++ b/tests/IvrControllerTest.php
@@ -8,14 +8,14 @@ class IvrControllerTest extends TestCase
 
     public function test_welcome_contains_age_options()
     {
-        $response = $this->post(route('welcome'));
+        $response = $this->post(route('welcome'), ['CallSid' => 'CA123']);
         $response->assertSee('Vuole proseguire col percorso digitale');
     }
 
     public function test_age_option_one_leads_to_main_menu()
     {
         $response = $this->post(route('age-response'), ['Digits' => '1']);
-        $response->assertSee('Ottima scelta');
+        $response->assertSee('scelta é a proprio rischio');
     }
 
     public function test_main_menu_is_accessible()
@@ -30,4 +30,11 @@ class IvrControllerTest extends TestCase
         $response->assertSee('Torna al menu principale');
         $response->assertSee('/ivr/main-menu');
     }
+
+    public function test_recording_callback_returns_no_content()
+    {
+        $response = $this->post(route('recording-cb'), ['RecordingSid' => 'test']);
+        $response->assertNoContent();
+    }
 }
+


### PR DESCRIPTION
## Summary
- Start recording via Twilio API when IVR call begins
- Add endpoint to log recording status callbacks
- Guard recording startup and log failures to avoid oversized TwiML errors

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68af6a05e9508327b675b403f5491590